### PR TITLE
Update hiera keys for CentOS, Debian and Ubuntu

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -8,6 +8,4 @@ puppetserver::version: 'installed'
 puppetserver::autosign: false
 puppetserver::java_args: '-Xms2g -Xmx2g -XX:MaxPermSize=256m'
 
-puppetserver::agent_version: 'installed'
-
 puppetserver::system_config_path: '/files/etc/sysconfig'

--- a/data/oses/distro/CentOS/6.yaml
+++ b/data/oses/distro/CentOS/6.yaml
@@ -1,3 +1,2 @@
-puppetserver::version: '5.1.4-1.el6'
-puppetserver::agent_version: '5.3.3-1.el6'
-puppetserver::puppetdb_version: '5.1.3-1.el6'
+puppetserver::version: '5.3.1-1.el6'
+puppetserver::puppetdb_version: '5.2.2-1.el6'

--- a/data/oses/distro/CentOS/7.yaml
+++ b/data/oses/distro/CentOS/7.yaml
@@ -1,3 +1,2 @@
-puppetserver::version: '5.1.4-1.el7'
-puppetserver::agent_version: '5.3.3-1.el7'
-puppetserver::puppetdb_version: '5.1.3-1.el7'
+puppetserver::version: '5.3.1-1.el7'
+puppetserver::puppetdb_version: '5.2.2-1.el7'

--- a/data/oses/distro/Debian/8.yaml
+++ b/data/oses/distro/Debian/8.yaml
@@ -1,3 +1,2 @@
-puppetserver::agent_version: '5.3.3-1jessie'
-puppetserver::version: '5.1.4-1jessie'
-puppetserver::puppetdb_version: '5.1.3-1jessie'
+puppetserver::version: '5.3.1-1jessie'
+puppetserver::puppetdb_version: '5.2.2-1jessie'

--- a/data/oses/distro/Debian/9.yaml
+++ b/data/oses/distro/Debian/9.yaml
@@ -1,0 +1,2 @@
+puppetserver::version: '5.3.1-1stretch'
+puppetserver::puppetdb_version: '5.2.2-1stretch'

--- a/data/oses/distro/Ubuntu/16.04.yaml
+++ b/data/oses/distro/Ubuntu/16.04.yaml
@@ -1,3 +1,2 @@
-puppetserver::agent_version: '5.3.3-1xenial'
-puppetserver::version: '5.1.4-1xenial'
-puppetserver::puppetdb_version: '5.1.3-1xenial'
+puppetserver::version: '5.3.1-1xenial'
+puppetserver::puppetdb_version: '5.2.2-1xenial'


### PR DESCRIPTION
Now the default versions are 5.3.1 for puppetserver and 5.2.2 for puppetdb_termini