### PR TITLE
dns_alt_names to main section

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -31,9 +31,9 @@ class puppetserver::config {
       notify  => Service['puppetserver']
   }
 
-  augeas {'puppetserver_master_dns_alt_names':
+  augeas {'puppetserver_main_dns_alt_names':
     context => '/files/etc/puppetlabs/puppet/puppet.conf',
-    changes => [ "set master/dns_alt_names ${puppetserver::dns_alt_names}", ],
+    changes => [ "set main/dns_alt_names ${puppetserver::dns_alt_names}", ],
     notify  => Service['puppetserver']
   }
 

--- a/spec/classes/puppetserver_spec.rb
+++ b/spec/classes/puppetserver_spec.rb
@@ -36,7 +36,7 @@ describe 'puppetserver', :type => :class do
           it { is_expected.to contain_augeas('puppetserver_main_runinterval').with({
             'context' => '/files/etc/puppetlabs/puppet/puppet.conf',
           })}
-          it { is_expected.to contain_augeas('puppetserver_master_dns_alt_names').with({
+          it { is_expected.to contain_augeas('puppetserver_main_dns_alt_names').with({
             'context' => '/files/etc/puppetlabs/puppet/puppet.conf',
           })}
           it { is_expected.to contain_augeas('puppetserver_java_args') }


### PR DESCRIPTION
Looking at the docs : https://puppet.com/docs/puppetserver/5.3/scaling_puppet_server.html#creating-and-configuring-compile-masters
Configure dns_alt_names in the [main] block of puppet.conf to cover every DNS name that might be used by an agent to access this master.

If this is put in the [master] section, the dns_alt_names are ignored when generating the cert using the initial puppet agent -t run